### PR TITLE
CI/CD: deploy pipeline (per-env vars) + ITPP-273 dual-push

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -20,6 +20,7 @@ on:
       role_arn:    { type: string, required: true }
       registry:    { type: string, required: true }
       ecr_repo:    { type: string, required: true }
+      legacy_ecr_repo: { type: string, required: false, default: '' }   # ITPP-273 backward-compat dual-push; remove after task-def flip
       image_tag:   { type: string, required: true }            # moving tag: dev | sandbox | master
       base_image:  { type: string, required: false, default: '' }   # optional Docker build-arg
       ecs_cluster: { type: string, required: false, default: '' }   # empty => skip ECS deploy
@@ -62,11 +63,18 @@ jobs:
           if [ -n "${{ inputs.base_image }}" ]; then
             BASE_ARG="--build-arg BASE_IMAGE=${{ inputs.base_image }}"
           fi
+          TAGS=(-t "$IMG:${{ github.sha }}" -t "$IMG:${{ inputs.image_tag }}")
+          # ITPP-273 backward-compat: also push to the legacy repo (same account) until the ECS task def flips.
+          # This is the buildx --push variant, so add legacy tags to the single multi-arch build rather than
+          # docker tag/push (the image is never loaded into the local daemon).
+          if [ -n "${{ inputs.legacy_ecr_repo }}" ]; then
+            LEG="${{ inputs.registry }}/${{ inputs.legacy_ecr_repo }}"
+            TAGS+=(-t "$LEG:${{ github.sha }}" -t "$LEG:${{ inputs.image_tag }}")
+          fi
           docker buildx build . \
             --platform=linux/amd64,linux/arm64 $BASE_ARG \
             --provenance=false \
-            -t "$IMG:${{ github.sha }}" \
-            -t "$IMG:${{ inputs.image_tag }}" \
+            "${TAGS[@]}" \
             --push
 
       - name: Deploy to ECS (auto-skips until cluster/service are provided)

--- a/.github/workflows/deploy-develop.yaml
+++ b/.github/workflows/deploy-develop.yaml
@@ -16,8 +16,8 @@ jobs:
     with:
       environment: dev
       aws_region:  us-east-2
-      role_arn:    arn:aws:iam::917220117358:role/github-actions-globalpayments-developer
-      registry:    917220117358.dkr.ecr.us-east-2.amazonaws.com
+      role_arn:    ${{ vars.DEV_ROLE_ARN }}
+      registry:    ${{ vars.DEV_REGISTRY }}
       ecr_repo:    tpp-gateway/globalpayments-python-service
       image_tag:   dev
       ecs_cluster: tpp-dev-ecs-cluster

--- a/.github/workflows/deploy-develop.yaml
+++ b/.github/workflows/deploy-develop.yaml
@@ -18,7 +18,8 @@ jobs:
       aws_region:  us-east-2
       role_arn:    ${{ vars.DEV_ROLE_ARN }}
       registry:    ${{ vars.DEV_REGISTRY }}
-      ecr_repo:    tpp-gateway/globalpayments-python-service
+      ecr_repo:    tpp-dev/global-payments
+      legacy_ecr_repo: tpp-gateway/globalpayments-python-service
       image_tag:   dev
       ecs_cluster: tpp-dev-ecs-cluster
       ecs_service: tpp-dev-globalpayments-service

--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -30,7 +30,8 @@ jobs:
       aws_region:  us-east-1
       role_arn:    ${{ vars.PROD_ROLE_ARN }}
       registry:    ${{ vars.PROD_REGISTRY }}
-      ecr_repo:    globalpayments-service
+      ecr_repo:    tpp-prod/global-payments
+      legacy_ecr_repo: globalpayments-service
       image_tag:   latest
       ecs_cluster: payments-prod-payments-cluster
       ecs_service: payments-prod-global-payments-service

--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -28,8 +28,8 @@ jobs:
     with:
       environment: production
       aws_region:  us-east-1
-      role_arn:    arn:aws:iam::907119984749:role/prod-deploy-payments-role
-      registry:    907119984749.dkr.ecr.us-east-1.amazonaws.com
+      role_arn:    ${{ vars.PROD_ROLE_ARN }}
+      registry:    ${{ vars.PROD_REGISTRY }}
       ecr_repo:    globalpayments-service
       image_tag:   latest
       ecs_cluster: payments-prod-payments-cluster

--- a/.github/workflows/deploy-sandbox.yaml
+++ b/.github/workflows/deploy-sandbox.yaml
@@ -16,8 +16,8 @@ jobs:
     with:
       environment: sandbox
       aws_region:  us-east-2
-      role_arn:    arn:aws:iam::917220117358:role/github-actions-globalpayments-developer
-      registry:    917220117358.dkr.ecr.us-east-2.amazonaws.com
+      role_arn:    ${{ vars.SANDBOX_ROLE_ARN }}
+      registry:    ${{ vars.SANDBOX_REGISTRY }}
       ecr_repo:    tpp-gateway/globalpayments-python-service
       image_tag:   sandbox
       ecs_cluster: tpp-sandbox-ecs-cluster

--- a/.github/workflows/deploy-sandbox.yaml
+++ b/.github/workflows/deploy-sandbox.yaml
@@ -18,7 +18,8 @@ jobs:
       aws_region:  us-east-2
       role_arn:    ${{ vars.SANDBOX_ROLE_ARN }}
       registry:    ${{ vars.SANDBOX_REGISTRY }}
-      ecr_repo:    tpp-gateway/globalpayments-python-service
+      ecr_repo:    tpp-sandbox/global-payments
+      legacy_ecr_repo: tpp-gateway/globalpayments-python-service
       image_tag:   sandbox
       ecs_cluster: tpp-sandbox-ecs-cluster
       ecs_service: tpp-sandbox-globalpayments-service


### PR DESCRIPTION
Reusable per-env deploy pipeline with `role_arn`/`registry` read from repo variables (`DEV_/SANDBOX_/PROD_`).

ITPP-273 — dual-push: each build now pushes to the new `tpp-<env>/global-payments` repos while still pushing the old repo for backward compatibility (`tpp-gateway/globalpayments-python-service` on dev/sandbox, `globalpayments-service` on prod). The legacy push is removed once the ECS task defs flip.
