### PR TITLE
ITPP-273: new per-env repos use :latest tag (catch-up for globalpayments)

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -21,7 +21,8 @@ on:
       registry:    { type: string, required: true }
       ecr_repo:    { type: string, required: true }
       legacy_ecr_repo: { type: string, required: false, default: '' }   # ITPP-273 backward-compat dual-push; remove after task-def flip
-      image_tag:   { type: string, required: true }            # moving tag: dev | sandbox | master
+      image_tag:   { type: string, required: true }            # new per-env repo moving tag (env is in the repo path) => 'latest'
+      legacy_image_tag: { type: string, required: false, default: '' }  # legacy shared-repo moving tag: dev | sandbox | latest
       base_image:  { type: string, required: false, default: '' }   # optional Docker build-arg
       ecs_cluster: { type: string, required: false, default: '' }   # empty => skip ECS deploy
       ecs_service: { type: string, required: false, default: '' }
@@ -69,7 +70,7 @@ jobs:
           # docker tag/push (the image is never loaded into the local daemon).
           if [ -n "${{ inputs.legacy_ecr_repo }}" ]; then
             LEG="${{ inputs.registry }}/${{ inputs.legacy_ecr_repo }}"
-            TAGS+=(-t "$LEG:${{ github.sha }}" -t "$LEG:${{ inputs.image_tag }}")
+            TAGS+=(-t "$LEG:${{ github.sha }}" -t "$LEG:${{ inputs.legacy_image_tag }}")
           fi
           docker buildx build . \
             --platform=linux/amd64,linux/arm64 $BASE_ARG \

--- a/.github/workflows/deploy-develop.yaml
+++ b/.github/workflows/deploy-develop.yaml
@@ -20,6 +20,7 @@ jobs:
       registry:    ${{ vars.DEV_REGISTRY }}
       ecr_repo:    tpp-dev/global-payments
       legacy_ecr_repo: tpp-gateway/globalpayments-python-service
-      image_tag:   dev
+      image_tag:   latest
+      legacy_image_tag: dev
       ecs_cluster: tpp-dev-ecs-cluster
       ecs_service: tpp-dev-globalpayments-service

--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -33,5 +33,6 @@ jobs:
       ecr_repo:    tpp-prod/global-payments
       legacy_ecr_repo: globalpayments-service
       image_tag:   latest
+      legacy_image_tag: latest
       ecs_cluster: payments-prod-payments-cluster
       ecs_service: payments-prod-global-payments-service

--- a/.github/workflows/deploy-sandbox.yaml
+++ b/.github/workflows/deploy-sandbox.yaml
@@ -20,6 +20,7 @@ jobs:
       registry:    ${{ vars.SANDBOX_REGISTRY }}
       ecr_repo:    tpp-sandbox/global-payments
       legacy_ecr_repo: tpp-gateway/globalpayments-python-service
-      image_tag:   sandbox
+      image_tag:   latest
+      legacy_image_tag: sandbox
       ecs_cluster: tpp-sandbox-ecs-cluster
       ecs_service: tpp-sandbox-globalpayments-service


### PR DESCRIPTION
Follow-up to #16 (merged with the old env tag). New tpp-<env>/global-payments repos now use ':latest' (ITPP-266 convention); legacy repo keeps its own tag via legacy_image_tag. No other changes.